### PR TITLE
Minor visual fixes to input box

### DIFF
--- a/src/components/InputPanel/InputPanel.ts
+++ b/src/components/InputPanel/InputPanel.ts
@@ -232,6 +232,7 @@ export class InputPanel extends QWidget {
     input.addEventListener(WidgetEventTypes.DragEnter, this.handleDrag.bind(this));
     input.addEventListener(WidgetEventTypes.KeyPress, this.handleKeyPress.bind(this));
     input.addEventListener(WidgetEventTypes.KeyRelease, this.handleKeyRelease.bind(this));
+    input.addEventListener('textChanged', this.adjustInputSize.bind(this));
 
     rootLayout.addWidget(addBtn);
     rootLayout.addWidget(input, 1);


### PR DESCRIPTION
Adjust input size on the 'textChanged' event, preventing the scroll bar from appearing and the text box from lagging behind the text when hitting shift+enter